### PR TITLE
add skip options

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
 
     <groupId>com.github.koraktor</groupId>
     <artifactId>mavanagaiata</artifactId>
-    <version>0.4.2-SNAPSHOT</version>
+    <version>0.4.1</version>
     <packaging>maven-plugin</packaging>
 
     <name>Mavanagaiata</name>

--- a/src/main/java/com/github/koraktor/mavanagaiata/git/GitRepository.java
+++ b/src/main/java/com/github/koraktor/mavanagaiata/git/GitRepository.java
@@ -20,9 +20,9 @@ public interface GitRepository {
     /**
      * Checks whether the Git repository is accessible.
      *
-     * @return false if the repository is not accessible.
+     * @throws GitRepositoryException if the repository is not accessible.
      */
-    public boolean check();
+    public void check() throws GitRepositoryException;
 
     /**
      * Closes any resources that are needed to access this repository

--- a/src/main/java/com/github/koraktor/mavanagaiata/git/jgit/JGitRepository.java
+++ b/src/main/java/com/github/koraktor/mavanagaiata/git/jgit/JGitRepository.java
@@ -95,8 +95,12 @@ public class JGitRepository extends AbstractGitRepository {
         this.commitCache = new HashMap<ObjectId, RevCommit>();
     }
 
-    public boolean check() {
-        return this.repository.getObjectDatabase().exists();
+    public void check() throws GitRepositoryException {
+        if (!this.repository.getObjectDatabase().exists()) {
+            File path = (this.repository.getDirectory() == null) ?
+                this.repository.getDirectory() : this.repository.getWorkTree();
+            throw new GitRepositoryException(path + " is not a Git repository");
+        }
     }
 
     /**

--- a/src/main/java/com/github/koraktor/mavanagaiata/mojo/AbstractGitMojo.java
+++ b/src/main/java/com/github/koraktor/mavanagaiata/mojo/AbstractGitMojo.java
@@ -164,8 +164,12 @@ public abstract class AbstractGitMojo extends AbstractMojo {
      */
     protected boolean init() throws MojoExecutionException {
         try {
-            return this.initRepository();
+            this.initRepository();
+            return true;
         } catch (GitRepositoryException e) {
+            if (skipNoGit) {
+                return false;
+            }
             throw new MojoExecutionException("Unable to initialize Mojo", e);
         }
     }
@@ -180,13 +184,8 @@ public abstract class AbstractGitMojo extends AbstractMojo {
     protected void initRepository()
             throws GitRepositoryException {
         this.repository = new JGitRepository(this.baseDir, this.gitDir);
-        if (!this.repository.check()) {
-            return false;
-        }
-
+        this.repository.check();
         this.repository.setHeadRef(this.head);
-
-        return true;
     }
 
     /**

--- a/src/test/java/com/github/koraktor/mavanagaiata/git/AbstractGitRepositoryTest.java
+++ b/src/test/java/com/github/koraktor/mavanagaiata/git/AbstractGitRepositoryTest.java
@@ -26,7 +26,7 @@ public class AbstractGitRepositoryTest {
 
     class GenericGitRepository extends AbstractGitRepository {
 
-        public boolean check() { return true; }
+        public void check() throws GitRepositoryException {}
 
         public void close() {}
 

--- a/src/test/java/com/github/koraktor/mavanagaiata/mojo/AbstractGitMojoTest.java
+++ b/src/test/java/com/github/koraktor/mavanagaiata/mojo/AbstractGitMojoTest.java
@@ -97,7 +97,7 @@ public class AbstractGitMojoTest extends MojoAbstractTest<AbstractGitMojo> {
         this.mojo.gitDir  = mock(File.class);
         when(this.mojo.gitDir.exists()).thenReturn(false);
 
-        assertThat(this.mojo.initRepository(), is(false));
+        assertThat(this.mojo.init(), is(false));
     }
 
     @Test


### PR DESCRIPTION
Hi,

we are using this plugin in an environment where we have a common base pom but sometimes builds are executed from non-git backed folders. Currently, the plugin (0.4.1) fails for us in that case. This patch adds a flag 'skipNoGit' which allows builds to succeed (obviously without setting the appropriate variables but that is fine). 

This also adds a 'skip' flag to skip execution completely. Most maven plugins have this to allow turning plugins on and off from the command line. So mavanagaiata should have that too. :-) 
