### PR TITLE
added explicit dirty flag to output

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ You may override this with the configuration property `propertyPrefixes`.
    * `committer.email`: The email address of the committer of the current
                         commit
    * `id` / `sha`:      The full SHA ID of the current commit
+   * `dirty`:           A boolean string indicating if the commit is dirty
  * `tag`
    * `name`:     The name of the most recent tag (if any)
    * `describe`: A combination of the tag name and the current commit ID

--- a/src/main/java/com/github/koraktor/mavanagaiata/mojo/GitCommitMojo.java
+++ b/src/main/java/com/github/koraktor/mavanagaiata/mojo/GitCommitMojo.java
@@ -50,6 +50,7 @@ public class GitCommitMojo extends AbstractGitMojo {
             GitCommit commit = this.repository.getHeadCommit();
             String abbrevId  = this.repository.getAbbreviatedCommitId();
             String shaId     = commit.getId();
+            boolean isDirty  = false;
 
             SimpleDateFormat dateFormat = new SimpleDateFormat(this.dateFormat);
             dateFormat.setTimeZone(commit.getAuthorTimeZone());
@@ -60,6 +61,7 @@ public class GitCommitMojo extends AbstractGitMojo {
             if (this.repository.isDirty(this.dirtyIgnoreUntracked)) {
                 abbrevId += this.dirtyFlag;
                 shaId    += this.dirtyFlag;
+                isDirty  = true;
             }
 
             this.addProperty("commit.abbrev", abbrevId);
@@ -71,6 +73,7 @@ public class GitCommitMojo extends AbstractGitMojo {
             this.addProperty("commit.committer.email", commit.getCommitterEmailAddress());
             this.addProperty("commit.id", shaId);
             this.addProperty("commit.sha", shaId);
+            this.addProperty("commit.dirty", String.valueOf(isDirty));
         } catch (GitRepositoryException e) {
             throw new MojoExecutionException("Unable to read Git commit information", e);
         }

--- a/src/test/java/com/github/koraktor/mavanagaiata/mojo/GitCommitMojoTest.java
+++ b/src/test/java/com/github/koraktor/mavanagaiata/mojo/GitCommitMojoTest.java
@@ -83,6 +83,7 @@ public class GitCommitMojoTest extends MojoAbstractTest<GitCommitMojo> {
         this.assertProperty("deadbeef-dirty", "commit.abbrev");
         this.assertProperty(headId, "commit.id");
         this.assertProperty(headId, "commit.sha");
+        this.assertProperty("true", "commit.dirty");
     }
 
     @Test
@@ -98,6 +99,7 @@ public class GitCommitMojoTest extends MojoAbstractTest<GitCommitMojo> {
         this.assertProperty("koraktor@gmail.com", "commit.committer.email");
         this.assertProperty("deadbeefdeadbeefdeadbeefdeadbeefdeadbeef", "commit.id");
         this.assertProperty("deadbeefdeadbeefdeadbeefdeadbeefdeadbeef", "commit.sha");
+        this.assertProperty("false", "commit.dirty");
     }
 
 }


### PR DESCRIPTION
I found myself needing to know both the base commit hash, and whether or not the repository was dirty at the time of the build, so I ended up parsing out the dirty flag from the commit id.

This change makes this case easier to handle; you can even set the dirtyFlag string to the empty string, and then the only indication of dirtiness will be this new property.

This change doesn't alter any existing behavior, so if you don't care to look at this new property, it shouldn't interfere with your build.
