### PR TITLE
Fix describe method of JGitRepository

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 target
+.classpath
+.project
+.settings

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
 
     <groupId>com.github.koraktor</groupId>
     <artifactId>mavanagaiata</artifactId>
-    <version>0.7.0</version>
+    <version>0.7.1-sn-SNAPSHOT</version>
     <packaging>maven-plugin</packaging>
 
     <prerequisites>
@@ -241,14 +241,14 @@
                 <version>3.1</version>
                 <configuration>
                     <encoding>${project.build.sourceEncoding}</encoding>
-                    <source>1.6</source>
-                    <target>1.6</target>
+                    <source>1.8</source>
+                    <target>1.8</target>
                 </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-plugin-plugin</artifactId>
-                <version>3.2</version>
+                <version>3.3</version>
                 <configuration>
                     <!--<extractors>
                         <extractor>java-annotations</extractor>
@@ -263,6 +263,12 @@
                             <goal>helpmojo</goal>
                         </goals>
                     </execution>
+                    <execution>
+                        <id>mojo-descriptor</id>
+                        <goals>
+                            <goal>descriptor</goal>
+                        </goals>
+                    </execution>
                 </executions>
             </plugin>
             <plugin>
@@ -275,6 +281,7 @@
                         <link>http://download.eclipse.org/jgit/docs/jgit-${jgit.version}/apidocs/</link>
                     </links>
                     <show>private</show>
+                    <additionalparam>-Xdoclint:none</additionalparam>
                 </configuration>
                 <executions>
                     <execution>
@@ -381,6 +388,7 @@
                         <link>http://download.eclipse.org/jgit/docs/jgit-${jgit.version}/apidocs/</link>
                     </links>
                     <show>private</show>
+                    <additionalparam>-Xdoclint:none</additionalparam>
                 </configuration>
                 <reportSets>
                     <reportSet>
@@ -393,7 +401,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-plugin-plugin</artifactId>
-                <version>3.2</version>
+                <version>3.3</version>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/src/main/java/com/github/koraktor/mavanagaiata/git/jgit/JGitRepository.java
+++ b/src/main/java/com/github/koraktor/mavanagaiata/git/jgit/JGitRepository.java
@@ -9,9 +9,9 @@ package com.github.koraktor.mavanagaiata.git.jgit;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.Arrays;
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Map;
 
 import org.eclipse.jgit.errors.AmbiguousObjectException;
@@ -23,6 +23,7 @@ import org.eclipse.jgit.lib.Ref;
 import org.eclipse.jgit.lib.Repository;
 import org.eclipse.jgit.revwalk.RevCommit;
 import org.eclipse.jgit.revwalk.RevFlag;
+import org.eclipse.jgit.revwalk.RevFlagSet;
 import org.eclipse.jgit.revwalk.RevObject;
 import org.eclipse.jgit.revwalk.RevTag;
 import org.eclipse.jgit.revwalk.RevWalk;
@@ -94,6 +95,7 @@ public class JGitRepository extends AbstractGitRepository {
         this.commitCache = new HashMap<ObjectId, RevCommit>();
     }
 
+    @Override
     public void check() throws GitRepositoryException {
         if (!this.repository.getObjectDatabase().exists()) {
             File path = (this.repository.isBare()) ?
@@ -109,6 +111,7 @@ public class JGitRepository extends AbstractGitRepository {
      *
      * @see Repository#close
      */
+    @Override
     public void close() {
         if (this.repository != null) {
             this.repository.close();
@@ -116,53 +119,147 @@ public class JGitRepository extends AbstractGitRepository {
         }
     }
 
-    public GitTagDescription describe() throws GitRepositoryException {
-        HashMap<RevCommit, String> tagCommits = new HashMap<RevCommit, String>();
-        for (Map.Entry<String, RevTag> tag : this.getRawTags().entrySet()) {
-            tagCommits.put((RevCommit) tag.getValue().getObject(), tag.getValue().getName());
+    /**
+     * This class represents a tag candidate which could be the latest tag in the branch.
+     */
+    private class TagCandidate {
+        private final RevTag commit;
+        private int distance;
+        private final RevFlag flag;
+
+        TagCandidate(RevTag commit, int distance, RevFlag flag) {
+            this.commit = commit;
+            this.distance = distance;
+            this.flag = flag;
         }
 
-        RevCommit start = this.getCommit(this.getHeadObject());
-        RevWalk revWalk = this.getRevWalk();
-        RevFlag seenFlag = revWalk.newFlag("SEEN");
+        boolean isRelated(RevCommit commit) {
+            return commit.has(flag);
+        }
+    }
 
-        int distance = -1;
-        GitTag nextTag = null;
-        HashSet<RevCommit> commits = new HashSet<RevCommit>();
-        commits.add(start);
-        while (!commits.isEmpty()) {
-            distance ++;
-            HashSet<RevCommit> nextCommits = new HashSet<RevCommit>();
+    @Override
+    public GitTagDescription describe() throws GitRepositoryException {
+        final Map<RevCommit,RevTag> tagCommits = new HashMap<RevCommit,RevTag>();
+        for (RevTag tag : this.getRawTags().values()) {
+            tagCommits.put((RevCommit)tag.getObject(), tag);
+        }
 
-            for (RevCommit currentCommit : commits) {
-                try {
-                    revWalk.parseHeaders(currentCommit);
-                } catch (IOException e) {
-                    throw new GitRepositoryException("Unable to parse headers of commit " + currentCommit.getName(), e);
-                }
+        final RevFlagSet allFlags = new RevFlagSet();
+        final RevCommit start = this.getCommit(this.getHeadObject());
+        final RevWalk revWalk = this.getRevWalk();
 
-                if (currentCommit.has(seenFlag)) {
-                    continue;
-                }
-                currentCommit.add(seenFlag);
+        try {
+            //Check, if the start commit is a tag already
+            if (tagCommits.containsKey(start)) {
+                start.add(RevFlag.SEEN);
+                GitTag tag = this.getTags().get(start.getId().getName());
+                return new GitTagDescription(this, this.getHeadCommit(), tag, 0);
+            }
 
-                if (tagCommits.containsKey(currentCommit)) {
-                    nextTag = this.getTags().get(currentCommit.getId().getName());
-                    break;
-                }
+            revWalk.markStart(start);
+            final Collection<TagCandidate> candidates = findTagCandidates(revWalk, tagCommits, allFlags);
 
-                if (currentCommit.getParents() != null) {
-                    nextCommits.addAll(Arrays.asList(currentCommit.getParents()));
+            if (candidates.isEmpty()) {
+                return new GitTagDescription(this, this.getHeadCommit(), null, -1);
+            }
+
+            //Now we have to correct the distance of the tag candidates
+            correctDistance(revWalk, candidates, allFlags);
+
+            int bestDistance = Integer.MAX_VALUE;
+            TagCandidate bestCandidate = null;
+            for (TagCandidate candidate : candidates) {
+                if (candidate.distance < bestDistance) {
+                    bestDistance = candidate.distance;
+                    bestCandidate = candidate;
                 }
             }
 
-            commits.clear();
-            commits.addAll(nextCommits);
+            GitTag tag = new JGitTag(bestCandidate.commit);
+            return new GitTagDescription(this, this.getHeadCommit(), tag, bestDistance);
+        } catch (Exception ex) {
+            throw new GitRepositoryException("Could not describe current branch.", ex);
+        } finally {
+            revWalk.release();
         }
-
-        return new GitTagDescription(this, this.getHeadCommit(), nextTag, distance);
     }
 
+    /**
+     * Find up to 10 tag candidates in the current branch. One of these should be the latest tag.
+     *
+     * @param revWalk Repository information
+     * @param tagCommits Map of commits that are associated with a tag
+     * @param allFlags All flags that have been set so far
+     *
+     * @return A collection of tag candidates
+     *
+     * @throws MissingObjectException
+     * @throws IncorrectObjectTypeException
+     * @throws IOException
+     */
+    private Collection<TagCandidate> findTagCandidates(RevWalk revWalk,
+            Map<RevCommit,RevTag> tagCommits, RevFlagSet allFlags)
+                    throws MissingObjectException, IncorrectObjectTypeException, IOException {
+        final Collection<TagCandidate> candidates = new ArrayList<TagCandidate>();
+        int distance = 0;
+        RevCommit commit;
+        while ((commit = revWalk.next()) != null) {
+            commit.add(RevFlag.SEEN);
+            if (!commit.hasAny(allFlags)) {
+                if (tagCommits.containsKey(commit)) {
+                    RevTag tagCommit = tagCommits.get(commit);
+                    RevFlag flag = revWalk.newFlag(tagCommit.getTagName());
+                    candidates.add(new TagCandidate(tagCommit, distance, flag));
+                    commit.add(flag);
+                    commit.carry(flag);
+                    revWalk.carry(flag);
+                    allFlags.add(flag);
+                }
+            }
+            for (TagCandidate candidate : candidates) {
+                if (!candidate.isRelated(commit)) {
+                    candidate.distance++;
+                }
+            }
+            if (candidates.size() >= 10) {
+                break;
+            }
+            distance++;
+        }
+        return candidates;
+    }
+
+    /**
+     * Correct the distance for all tag candidates. We have to check all branches to get the correct
+     * distance at the end.
+     *
+     * @param revWalk Repository information
+     * @param candidates Collection of tag candidates
+     * @param allFlags All flags that have been set so far
+     *
+     * @throws MissingObjectException
+     * @throws IncorrectObjectTypeException
+     * @throws IOException
+     */
+    private void correctDistance(RevWalk revWalk, Collection<TagCandidate> candidates, RevFlagSet allFlags)
+            throws MissingObjectException, IncorrectObjectTypeException, IOException {
+        RevCommit commit;
+        while ((commit = revWalk.next()) != null) {
+            if (commit.hasAll(allFlags)) {
+                // The commit has all flags already, so we just mark the parents as seen.
+                for (RevCommit parent : commit.getParents())
+                    parent.add(RevFlag.SEEN);
+            } else {
+                for (TagCandidate candidate : candidates) {
+                    if (!candidate.isRelated(commit))
+                        candidate.distance++;
+                }
+            }
+        }
+    }
+
+    @Override
     public String getAbbreviatedCommitId(GitCommit commit) throws GitRepositoryException {
         try {
             RevCommit rawCommit = ((JGitCommit) commit).commit;
@@ -175,6 +272,7 @@ public class JGitRepository extends AbstractGitRepository {
         }
     }
 
+    @Override
     public String getBranch() throws GitRepositoryException {
         try {
             return this.repository.getBranch();
@@ -183,10 +281,12 @@ public class JGitRepository extends AbstractGitRepository {
         }
     }
 
+    @Override
     public JGitCommit getHeadCommit() throws GitRepositoryException {
         return new JGitCommit(this.getCommit(this.getHeadObject()));
     }
 
+    @Override
     public Map<String, GitTag> getTags()
             throws GitRepositoryException {
         Map<String, GitTag> tags = new HashMap<String, GitTag>();
@@ -198,10 +298,12 @@ public class JGitRepository extends AbstractGitRepository {
         return tags;
     }
 
+    @Override
     public File getWorkTree() {
         return this.repository.getWorkTree();
     }
 
+    @Override
     public boolean isDirty(boolean ignoreUntracked) throws GitRepositoryException {
         try {
             FileTreeIterator workTreeIterator = new FileTreeIterator(this.repository);
@@ -220,6 +322,7 @@ public class JGitRepository extends AbstractGitRepository {
         }
     }
 
+    @Override
     public void walkCommits(CommitWalkAction action)
             throws GitRepositoryException {
         try {


### PR DESCRIPTION
I have included mavanagaiata 0.7.0 in a project and everything was working fine. Then we switched this project to Java 8. From this day on, mavanagaiata did not find the correct, latest, tag in the branch, but a very old one.

First I thought this is just an issue with Java 8. But after a closer look to the implementation of the describe function, I discovered that the implementation is not complete.
We use many branches in out project. The existing implementation does not follow all branches. In case one commit has two parents, it just follows one of the parents.

With this pull request a new implementation is used, which is based on the RevWalk class.