### PR TITLE
Few cleanups in the pom to correct warnings / errors

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -284,6 +284,7 @@
                     <encoding>${project.build.sourceEncoding}</encoding>
                     <source>11</source>
                     <target>11</target>
+                    <release>11</release>
                 </configuration>
             </plugin>
             <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -316,11 +316,11 @@
                         <additionalOption>-html5</additionalOption>
                     </additionalOptions>
                     <links>
-                        <link>https://docs.oracle.com/javase/8/docs/api</link>
+                        <link>https://docs.oracle.com/javase/11/docs/api</link>
                     </links>
                     <locale>en_US</locale>
                     <show>private</show>
-                    <source>8</source>
+                    <source>11</source>
                 </configuration>
                 <executions>
                     <execution>
@@ -426,10 +426,10 @@
                         <additionalOption>-html5</additionalOption>
                     </additionalOptions>
                     <links>
-                        <link>https://docs.oracle.com/javase/8/docs/api</link>
+                        <link>https://docs.oracle.com/javase/11/docs/api</link>
                     </links>
                     <locale>en_US</locale>
-                    <source>8</source>
+                    <source>11</source>
                 </configuration>
                 <reportSets>
                     <reportSet>

--- a/pom.xml
+++ b/pom.xml
@@ -317,7 +317,6 @@
                     </additionalOptions>
                     <links>
                         <link>https://docs.oracle.com/javase/8/docs/api</link>
-                        <link>https://download.eclipse.org/jgit/site/${jgit.version}/apidocs</link>
                     </links>
                     <locale>en_US</locale>
                     <show>private</show>
@@ -428,7 +427,6 @@
                     </additionalOptions>
                     <links>
                         <link>https://docs.oracle.com/javase/8/docs/api</link>
-                        <link>https://download.eclipse.org/jgit/site/${jgit.version}/apidocs</link>
                     </links>
                     <locale>en_US</locale>
                     <source>8</source>


### PR DESCRIPTION
- since java 9, <release> tag should be used with compiler.  The older source/target are obsolete but left those for now.
- jgit javadoc location does not exist.  There is a newer location but any specific version redirects to latest and its not necessary here.  Maybe some older issue with maven that isn't present now.  The build completely failed when javadocs invoked for me.  Using jdk 22 but don't think that specifically matters.
- Since target is java 11, make sure javadocs are too.