### PR TITLE
[maven] Require maven 3.6.3 or better per maven policy

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
     <packaging>maven-plugin</packaging>
 
     <prerequisites>
-        <maven>3.3.9</maven>
+        <maven>3.6.3</maven>
     </prerequisites>
 
     <name>Mavanagaiata</name>


### PR DESCRIPTION
maven has flagged all before 3.6.3 to be obsolete and suggested all go to 3.6.3.  All core plugins already require it.